### PR TITLE
Minor corrections in README.md and pb-motif.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Clinical CAH sample:
 `    -i sample_data/cyp21a2_normal_01/reads.p \ `  
 `    -m motifs/motifs_cyp21a2-a1p.p \ `  
 `    -o output_dir/ \ `  
-`    --pc 100`
+`    -pc 100`
 
 In this case the input data is a pickle of pre-processed reads where motifs have already been identified. These pickles can be saved using the `-p` option. Additionally, `-pc 100` is used so that PB-Motif only outputs plots corresponding to clusters of reads supported by at least 100 reads.

--- a/pb-motif.py
+++ b/pb-motif.py
@@ -179,7 +179,7 @@ elif isFASTQ or isFASTA:
 		nTOT      = int(int([n for n in out.decode('utf-8').split(' ') if len(n)][0])/lineDivisor)
 		f = open(INF,'r')
 	else:
-		ps   = subprocess.Popen(['gzcat',INF], stdout=subprocess.PIPE)
+		ps   = subprocess.Popen(['zcat',INF], stdout=subprocess.PIPE)
 		out  = subprocess.check_output(['wc','-l'], stdin=ps.stdout)
 		ps.wait()
 		nTOT = int(int([n for n in out.decode('utf-8').split(' ') if len(n)][0])/lineDivisor)


### PR DESCRIPTION
A small correction in the `README.md` file -
Example usage command for clinical CAH sample had `--pc 100`, but correct is `-pc 100`

Another small correction in `pb-motif.py` script -
Line 182 can be changed to 
`ps   = subprocess.Popen(['zcat',INF], stdout=subprocess.PIPE)`, 
since hardcoding `gzcat` gave this error "file not found" with the testing command and sample data files.